### PR TITLE
Replace count fn call on string with strlen (breaks in PHP > 7.1)

### DIFF
--- a/src/Commands/MigrationCommand.php
+++ b/src/Commands/MigrationCommand.php
@@ -129,7 +129,7 @@ class MigrationCommand extends BaseCommand {
             $key['column'] = 'id';
         }
         if(! $key['table']){
-            $key['table'] = str_plural(substr($key['name'], 0, count($key['name']) - 4));
+            $key['table'] = str_plural(substr($key['name'], 0, strlen($key['name']) - 4));
         }
 
         $constraint = $this->getTemplate('migration/foreign-key')


### PR DESCRIPTION
Minor bugfix:  When you use `count()` on a `string` in  `PHP 7.2` you get this:

```php
count(): Parameter must be an array or an object that implements Countable
```
Replaced with `strlen()`.